### PR TITLE
Show "yet to tee off" for live players who haven't started

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -401,7 +401,16 @@ function detailHtml(p, d) {
         : ` <span class="note-flag" title="${DOUBLES_NOTE}">⚑ ${p.dbl ? "partner TBD" : "teams TBD"}</span>`;
     }
     if (e.cls === "playoff") note += ` <span class="note-flag" title="${PLAYOFF_NOTE}">⚑ assumes qualifiers attend</span>`;
-    if (isLive) note += ` <span class="live-badge"><span class="live-dot"></span>live · now ${s.live.cur >= 0 ? "+" : ""}${s.live.cur}, proj ${ordinal(Math.round(s.live.mean_place))}</span>`;
+    if (isLive) {
+      // rem carries rounds left, so (rounds - rem) * 18 = holes played. A
+      // player still on their pre-tournament even par with a full slate left
+      // hasn't teed off yet — show that instead of a misleading "now +0".
+      const thru = Math.round((e.rounds - s.live.rem) * 18);
+      const pos = thru <= 0
+        ? "yet to tee off"
+        : `now ${s.live.cur >= 0 ? "+" : ""}${s.live.cur} thru ${thru}`;
+      note += ` <span class="live-badge"><span class="live-dot"></span>live · ${pos}, proj ${ordinal(Math.round(s.live.mean_place))}</span>`;
+    }
     // live events are locked in (player is in the field) → checkbox disabled
     return `<tr class="${att <= 0.001 && !isLive ? "not-att" : ""}">
       <td><input type="checkbox" class="wf-box" data-tid="${e.tid}" ${dflt} ${isLive ? "disabled" : ""}></td>


### PR DESCRIPTION
## Summary

Follow-up to the live-field fix (#4). That change put not-yet-started players into a live event's field so the odds account for the full field — but they sit at even par (`cur = 0`) with the whole event ahead, and the per-event breakdown rendered that literally as **"now +0"**, reading as if they were even through some holes rather than waiting to tee off.

This derives holes played from the rounds-remaining value already in the live payload and shows:

- **"yet to tee off"** when a player has a full slate remaining, and
- **"now +X thru N"** once they're on the course (which also disambiguates mid-round scores).

Purely a rendering change in `docs/app.js` — no data regeneration needed; it works with the data already published.

## Verification

Validated the `thru` derivation against the live Heinola data on `main`: the 73 players on the course classify as started (thru 18 after round 1), and the 32 not-yet-out (Gannon Buhr, Calvin Heimburg, …) classify as "yet to tee off." `node -c` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_