### PR TITLE
Drive live refresh cadence from a self-relaying loop

### DIFF
--- a/.github/workflows/live-refresh.yml
+++ b/.github/workflows/live-refresh.yml
@@ -1,12 +1,24 @@
 name: Live refresh
 
-# Keep the site near-real-time during play. The cron fires every 15 minutes,
-# but a cheap change-check (no numpy, no sim) runs first and skips the heavy
-# refresh unless a live event's scores moved or an event just finalized. So
-# between rounds and overnight it idles instead of re-simulating every 15 min.
+# Keep the site near-real-time during play.
+#
+# GitHub's scheduled `cron` trigger is best-effort and, under load, only
+# actually fires every 1.5-3h — far too slow to track a live round. So the
+# cron is NOT the cadence here; it only (re)starts the loop below. Once a run
+# is going, it drives its own tight cadence: every ~5 minutes it runs a cheap
+# change-check (stdlib only, no sim) and re-simulates only when a live event's
+# scores actually moved. It keeps looping until no points event is live or it
+# nears the 6h per-job ceiling, then yields.
+#
+# Continuation across that ceiling needs no PAT: the shared concurrency group
+# keeps exactly one run active and one queued, and the coarse cron reliably
+# leaves a queued successor during any 5.5h window, so it starts the instant
+# the active run yields. Between rounds / overnight the loop idles on the cheap
+# check (no pip, no sim) and, when nothing is live, exits in seconds. Public
+# repo => Actions minutes are free, so holding a runner during an event is fine.
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/15 * * * *"   # only needs to (re)start / keep a successor queued
   workflow_dispatch: {}
 
 permissions:
@@ -20,61 +32,70 @@ concurrency:
 jobs:
   live:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 350   # stay under GitHub's 6h ceiling; loop yields first
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      # cheap gate first (stdlib only, no pip/sim): has anything actually moved?
-      - name: Change check
-        id: check
-        run: python -m dgpt.livecheck
-
       - name: Restore results cache
-        if: steps.check.outputs.changed == 'true'
         uses: actions/cache@v4
         with:
           path: data/cache
           key: pdga-cache-2026-${{ github.run_id }}
           restore-keys: pdga-cache-2026-
-      - name: Install dependencies
-        if: steps.check.outputs.changed == 'true'
-        run: pip install -r requirements.txt
-      - name: Refresh
-        if: steps.check.outputs.changed == 'true'
+
+      - name: Drive the live refresh loop
         env:
           PDGA_USERNAME: ${{ secrets.PDGA_USERNAME }}
           PDGA_PASSWORD: ${{ secrets.PDGA_PASSWORD }}
-        run: python -m dgpt.refresh --sims 100000
-      - name: Commit if anything changed
-        id: commit
-        if: steps.check.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data docs/data results predictions
-          if git diff --cached --quiet -I'"generated":'; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            git commit -m "Live refresh ($(date -u +'%F %H:%MZ'))"
-            git push
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Trigger Pages build (retry on transient deploy failure)
-        if: steps.commit.outputs.changed == 'true'
-        env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          for attempt in 1 2 3; do
-            gh api -X POST "repos/${{ github.repository }}/pages/builds" >/dev/null
-            for i in $(seq 1 20); do
-              sleep 10
-              status=$(gh api "repos/${{ github.repository }}/pages/builds/latest" --jq .status)
-              echo "attempt $attempt: $status"
-              [ "$status" = "built" ] && exit 0
-              [ "$status" = "errored" ] && break
-            done
+          set -uo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BUDGET=$(( $(date +%s) + 330 * 60 ))   # ~5.5h, then yield to the successor
+          deps_ready=0
+
+          is_live() {
+            python -c "import sys; from dgpt import schedule; sys.exit(0 if schedule.live_events() else 1)"
+          }
+
+          while :; do
+            if ! is_live; then
+              echo "No points event live — exiting (cron will restart when one is)."
+              break
+            fi
+
+            # cheap gate (stdlib only): does anything actually need re-simulating?
+            status=$(env -u GITHUB_OUTPUT python -m dgpt.livecheck | tail -n1)
+            echo "change-check: $status"
+
+            if [ "$status" = "changed" ]; then
+              if [ "$deps_ready" = "0" ]; then
+                pip install -r requirements.txt
+                deps_ready=1
+              fi
+              python -m dgpt.refresh --sims 100000
+              git add data docs/data results predictions
+              if git diff --cached --quiet -I'"generated":'; then
+                echo "nothing to commit after refresh"
+              else
+                git commit -m "Live refresh ($(date -u +'%F %H:%MZ'))"
+                # a concurrent merge/weekly refresh could have moved main
+                git push || { git pull --rebase --autostash && git push; }
+                # nudge Pages (best-effort; data commit has already landed)
+                gh api -X POST "repos/${GITHUB_REPOSITORY}/pages/builds" >/dev/null 2>&1 || true
+              fi
+            fi
+
+            if [ "$(date +%s)" -ge "$BUDGET" ]; then
+              echo "Near job time limit — yielding; the queued successor takes over."
+              break
+            fi
+            sleep 300
           done
-          echo "::warning::Pages did not reach 'built' after 3 attempts (data commit still landed)"


### PR DESCRIPTION
## Problem

The live-refresh workflow is set to `*/15 * * * *`, but GitHub's scheduled `cron` trigger is best-effort and, under load, only actually fires every ~1.5–3h. Every run *succeeds* — the change-check, sim, commit and Pages deploy all complete — but the site can sit hours stale mid-round because the trigger simply doesn't fire often enough. Observed today during Heinola: refreshes at 11:56 → 14:46 (nearly 3h apart) while round 1 was being played.

## Fix

Stop using the scheduler for cadence. While a points event is live, a single run drives its own loop:

- every ~5 min it runs the existing cheap change-check (`dgpt.livecheck`, stdlib only — no pip, no sim),
- re-simulates + commits **only** when a live event's scores actually moved,
- yields before GitHub's 6h per-job ceiling.

The `cron` is demoted to just (re)starting the loop and keeping a successor queued. **No PAT needed:** the shared `refresh-forecast` concurrency group keeps exactly one run active and one queued, and even a throttled cron reliably leaves a queued successor within any 5.5h window, so it takes over the instant the active run yields. When nothing is live (overnight / off-season) the loop exits in seconds and the repo falls back to the same cheap idle behavior as before.

Net effect: near-real-time during play (~5 min), unchanged cheap idling otherwise. Public repo, so the continuous runner time during an event is free.

## Notes / trade-offs

- Dependencies are installed lazily (only before the first actual refresh), so idle loops stay cheap.
- Push uses a `pull --rebase --autostash` fallback in case a merge or the weekly refresh moved `main`.
- The weekly full refresh shares the concurrency group and runs the same command, so it's never starved of anything meaningful — it just waits for the current loop to yield.

## Validation

`yaml.safe_load` parses the workflow; `bash -n` passes on the embedded loop; confirmed `dgpt.livecheck` imports with no numpy/pandas/requests so it runs before `pip install`, matching the prior pre-install usage. Can't exercise the Actions scheduler from here — worth watching the first live run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_