### PR TITLE
Ride out StatMando mid-update; deploy Pages before validating

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -63,12 +63,12 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # After the commit: a failure here marks the run failed (owner gets
-      # notified) without blocking the data publish. Runs weekly rather than
-      # in the live cron because StatMando can lag right after events.
-      - name: Validate standings against StatMando
-        run: python -m dgpt.validate
-
+      # Deploy BEFORE validating: a validate failure must mark the run red
+      # (owner gets notified) without blocking the publish. With the deploy
+      # after it, a validate failure skipped this step and left the site
+      # serving stale data (observed 2026-07-13: StatMando's FPO page was
+      # mid-update, validate exited 1, and with no live event to push again
+      # the site would have sat stale until Thursday's refresh).
       - name: Trigger Pages build (retry on transient deploy failure)
         if: steps.commit.outputs.changed == 'true'
         env:
@@ -88,3 +88,9 @@ jobs:
             done
           done
           echo "::warning::Pages did not reach 'built' after 3 attempts (data commit still landed)"
+
+      # Last step: a failure here fails the run (owner gets notified) after
+      # the data commit and deploy have already gone out. Runs weekly rather
+      # than in the live cron because StatMando can lag right after events.
+      - name: Validate standings against StatMando
+        run: python -m dgpt.validate

--- a/dgpt/validate.py
+++ b/dgpt/validate.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import html
 import re
 import sys
+import time
 import urllib.request
 
 from . import standings
@@ -23,6 +24,9 @@ from . import standings
 STATMANDO = "https://statmando.com/rankings/dgpt/{div}"
 UA = {"User-Agent": "Mozilla/5.0 (dgpt-forecast validation; github.com/dgoodenough/discgolf)"}
 TOLERANCE = 0.02  # points; StatMando displays 2 decimals
+MIN_ROWS = 50      # fewer parsed rows than this = page empty / mid-update / reshaped
+FETCH_ATTEMPTS = 4
+FETCH_RETRY_WAIT = 120  # seconds; rankings pages are briefly empty while they ingest
 
 
 def statmando_totals(division: str) -> dict[str, float]:
@@ -41,9 +45,22 @@ def statmando_totals(division: str) -> dict[str, float]:
 
 def check(division: str) -> tuple[list[str], list[str]]:
     """Returns (errors, warnings) for one division."""
-    official = statmando_totals(division)
-    if len(official) < 50:  # page shape changed or partial load
-        return [f"{division}: StatMando parse produced only {len(official)} rows — page layout may have changed"], []
+    # Retry a thin parse: the Monday run lands while StatMando ingests the
+    # weekend's results, and a division's page can be briefly empty (observed
+    # 2026-07-13: MPO parsed fine while FPO returned 0 rows minutes after the
+    # weekend finished). Only a *persistently* thin page is an error — that's
+    # the signal the layout actually changed.
+    for attempt in range(FETCH_ATTEMPTS):
+        official = statmando_totals(division)
+        if len(official) >= MIN_ROWS:
+            break
+        if attempt < FETCH_ATTEMPTS - 1:
+            print(f"  {division}: parse returned {len(official)} rows — "
+                  f"retrying in {FETCH_RETRY_WAIT}s (their site may be mid-update)")
+            time.sleep(FETCH_RETRY_WAIT)
+    if len(official) < MIN_ROWS:  # page shape changed or persistently empty
+        return [f"{division}: StatMando parse produced only {len(official)} rows "
+                f"after {FETCH_ATTEMPTS} attempts — page layout may have changed"], []
     ours = {r["name"]: r["points"] for r in standings.compute(division)}
 
     errors, warnings = [], []
@@ -65,7 +82,7 @@ def main() -> None:
     all_errors: list[str] = []
     for division in ("MPO", "FPO"):
         errors, warnings = check(division)
-        matched_msg = "OK" if not errors else f"{len(errors)} POINT DIFFS"
+        matched_msg = "OK" if not errors else f"{len(errors)} ISSUE(S)"
         print(f"{division}: {matched_msg}")
         for w in warnings[:10]:
             print(f"  warn: {w}")


### PR DESCRIPTION
## What happened (Monday 2026-07-13, 13:17Z run)

The weekly `Refresh forecast` run failed in the `validate` step:

```
MPO: OK
  ERROR: FPO: StatMando parse produced only 0 rows — page layout may have changed
```

Not engine drift — MPO validated exactly at the same moment, and the data commit had already gone out. StatMando was ingesting the weekend's (Heinola) results when we hit their FPO page, and it came back empty. Their site self-healed; ours needed two fixes:

## Fix 1: retry a thin StatMando parse (`dgpt/validate.py`)

A division whose page parses to fewer than 50 rows is now refetched up to 4 times, 120 s apart, before being reported as an error. A transient mid-update window passes; a *persistently* thin page still fails the run, since that's the genuine layout-changed signal. (Also relabeled the summary line — the failure printed as "1 POINT DIFFS" when no points were actually compared.)

Verified with mocked fetches: empty-twice-then-good passes after 3 attempts; persistently-empty errors after all 4.

## Fix 2: deploy Pages before validating (`.github/workflows/refresh.yml`)

The Pages-deploy-with-retry step sat *after* validate, so validate's exit 1 skipped it. The push-triggered Pages build happened to fail on its own at 13:21Z (the second failure in the Actions list), and with Heinola over there was no live event to push again — the site would have served stale data until Thursday. The deploy step now runs immediately after the commit, and validate runs last, matching its documented intent: a validation failure marks the run red and notifies, but never blocks the publish.

(The stale site itself was already unstuck by re-running the failed Pages build — deployed successfully at 14:15Z on today's refresh commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_