### PR TITLE
Project event finishes against the real field, not a Gaussian summary

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -341,15 +341,54 @@ function eventProj(d, p, e) {
   return projectPoints(d, p, e, 2500, rating);
 }
 
+/* Everyone (other than `selfPdga`) expected at event e: {r: rating, a: P(plays)}.
+   The bundle's per-player att arrays share d.events' ordering. */
+function eventField(d, e, selfPdga) {
+  const ei = d.events.findIndex((x) => x.tid === e.tid);
+  const out = [];
+  if (ei < 0) return out;
+  for (const q of d.players) {
+    if (q.pdga !== selfPdga && q.rating && q.att[ei] > 0.001) out.push({ r: q.rating, a: q.att[ei] });
+  }
+  return out;
+}
+
+/* One draw of finishing place for `rating` against the event's real field:
+   sample who shows up, give everyone a rating-based score, count who beat you.
+   This replaces a one-Gaussian summary of the field (field_avg_rating /
+   opp_score_sd), which broke on bimodal open fields — at the USWDGC the club-
+   level entrants doubled opp_score_sd, and the model concluded the 990-rated
+   favorites were beatable by anyone, crushing their win odds ~5x. Only the
+   score DIFFERENCES matter for ranking, so the field-average offset cancels. */
+function drawPlace(d, e, rating, field) {
+  const k = d.meta.rating_pts_per_stroke;
+  const sd = d.meta.round_sd * Math.sqrt(e.rounds);
+  const mine = (-rating / k) * e.rounds + sd * randn();
+  let beat = 0;
+  for (const q of field) {
+    if (q.a < 1 && Math.random() >= q.a) continue;
+    if ((-q.r / k) * e.rounds + sd * randn() < mine) beat++;
+  }
+  return 1 + beat;
+}
+
 function projectPoints(d, p, e, draws = 2500, rating = p.rating) {
+  // doubles stays on the Gaussian shortcut: its curve is TEAM-place indexed
+  // and the team field is unimodal tour pairs, where the summary holds up
+  const field = e.tid === d.meta.dbl_tid ? null : eventField(d, e, p.pdga);
   const out = new Float64Array(draws);
   const places = new Float64Array(draws);
   let wins = 0;
   for (let i = 0; i < draws; i++) {
-    const mu = (-(rating - e.field_avg_rating) / d.meta.rating_pts_per_stroke) * e.rounds;
-    const s = mu + d.meta.round_sd * Math.sqrt(e.rounds) * randn();
-    const lam = Math.min(e.field_size, e.field_size * PHI(s / e.opp_score_sd));
-    const place = 1 + Math.min(poisson(lam), Math.round(e.field_size));
+    let place;
+    if (field) {
+      place = drawPlace(d, e, rating, field);
+    } else {
+      const mu = (-(rating - e.field_avg_rating) / d.meta.rating_pts_per_stroke) * e.rounds;
+      const s = mu + d.meta.round_sd * Math.sqrt(e.rounds) * randn();
+      const lam = Math.min(e.field_size, e.field_size * PHI(s / e.opp_score_sd));
+      place = 1 + Math.min(poisson(lam), Math.round(e.field_size));
+    }
     if (place === 1) wins++;
     places[i] = place;
     out[i] = place <= e.curve.length ? e.curve[place - 1] : 0;
@@ -486,6 +525,30 @@ function replay(d, p, attendSet) {
   for (const b of p.banked) banked[POOL_BY_CLS[b.cls] || "dgpt"].push(b.pts);
   const events = d.events.filter((e) => attendSet.has(e.tid));
   const n = d.cutline.length;
+  // Pre-sample each event's points distribution against its REAL field (same
+  // model as projectPoints — the one-Gaussian shortcut broke on bimodal open
+  // fields like the USWDGC), then draw by index inside the hot loop so the
+  // replay stays under its time budget. Doubles keeps the Gaussian shortcut
+  // (team-indexed curve, unimodal team field).
+  const SAMPLES = 1500;
+  const ptsSamples = events.map((e) => {
+    const rating = e.tid === d.meta.dbl_tid && p.dbl ? p.dbl.team_rating : p.rating;
+    const field = e.tid === d.meta.dbl_tid ? null : eventField(d, e, p.pdga);
+    const arr = new Float64Array(SAMPLES);
+    for (let i = 0; i < SAMPLES; i++) {
+      let place;
+      if (field) {
+        place = drawPlace(d, e, rating, field);
+      } else {
+        const mu = (-(rating - e.field_avg_rating) / d.meta.rating_pts_per_stroke) * e.rounds;
+        const s = mu + d.meta.round_sd * Math.sqrt(e.rounds) * randn();
+        const lam = Math.min(e.field_size, e.field_size * PHI(s / e.opp_score_sd));
+        place = 1 + Math.min(poisson(lam), Math.round(e.field_size));
+      }
+      arr[i] = place <= e.curve.length ? e.curve[place - 1] : 0;
+    }
+    return arr;
+  });
   // blended cutline ≈ "points of the last spot among OTHER players":
   // if this player was probably inside the cut in the base sim, the true
   // exclusive cutline is closer to the (cut+1)-th total.
@@ -493,13 +556,9 @@ function replay(d, p, attendSet) {
   let qualify = 0, sumPts = 0;
   for (let i = 0; i < n; i++) {
     const pools = { dgpt: banked.dgpt.slice(), playoff: banked.playoff.slice(), major: banked.major.slice(), jomez: banked.jomez.slice() };
-    for (const e of events) {
-      const mu = (-(p.rating - e.field_avg_rating) / d.meta.rating_pts_per_stroke) * e.rounds;
-      const s = mu + d.meta.round_sd * Math.sqrt(e.rounds) * randn();
-      const lam = Math.min(e.field_size, e.field_size * PHI(s / e.opp_score_sd));
-      const place = 1 + Math.min(poisson(lam), Math.round(e.field_size));
-      const pts = place <= e.curve.length ? e.curve[place - 1] : 0;
-      pools[POOL_BY_CLS[e.cls] || "dgpt"].push(pts);
+    for (let ev = 0; ev < events.length; ev++) {
+      const pts = ptsSamples[ev][(Math.random() * SAMPLES) | 0];
+      pools[POOL_BY_CLS[events[ev].cls] || "dgpt"].push(pts);
     }
     const total = seasonTotal(pools, d.meta);
     const cl = w * d.cutline2[i] + (1 - w) * d.cutline[i];


### PR DESCRIPTION
## Bug

Win odds for USWDGC favorites were 5–8× too low (reported as "at least 3×"). Saarinen (990-rated) showed ~4.5% to win; the real number is ~22%.

## Root cause

For non-live events, the app's per-event projection (`projectPoints`) and the what-if replay both modeled the opposition as a **single Gaussian** (`field_avg_rating` / `opp_score_sd` from the sim's events_meta) and drew place as `1 + Poisson(field_size · Φ(z))`. That summary collapses on **bimodal open fields**: USWDGC's field spans 805→990 rating (tour pros + club-level entrants), which doubles `opp_score_sd` vs a normal stop (26.2 vs ~11–15). The inflated spread makes the model believe anyone can beat the favorites:

| Player | old model | field-aware |
|---|---|---|
| Silva Saarinen (990) | 4.5% | 22.4% |
| Ohn Scoggins (989) | 3.8% | 20.9% |
| Holyn Handley (987) | 3.4% | 17.4% |
| Missy Gannon (984) | 1.8% | 12.8% |

Median projected places for the favorites move from ~12th to 3rd–6th, and the top five now hold ~82% of the win probability, as an 805–990 field should.

## Fix

Draw against the event's **real expected field** — every player's rating × attendance odds, which the bundle already carries (`p.att` aligned to `d.events`): sample who shows up, score everyone off their rating, count who beat you. Only score differences matter for ranking, so the field-average offset cancels.

- **`projectPoints`**: field-aware draw per sample. ~10 ms per event per player — imperceptible on row expand.
- **`replay` (what-if)**: same model via per-event **pre-sampled points distributions** (1500 samples each, ~30 ms for all events), indexed inside the 25k-iteration hot loop so the &lt;100 ms budget holds.
- **Doubles championship** keeps the Gaussian shortcut deliberately: its curve is team-place indexed and its team field is unimodal, where the summary is sound.

## Verification

Ran the actual functions extracted from `app.js` under node against the published bundles: USWDGC numbers above; unimodal tour stops shift modestly and in one direction (e.g. Buhr at Ledgestone 21.8% → 29.7% — the Poisson summary understated favorites everywhere, mildly on normal fields, catastrophically on bimodal ones). `node -c` passes.

Client-only change — no data regeneration needed; takes effect on the next Pages deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_