### PR TITLE
Hotfix: module shadowing crash in simulate.run (breaks every refresh)

### DIFF
--- a/dgpt/simulate.py
+++ b/dgpt/simulate.py
@@ -13,7 +13,10 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from . import config, fields, live_api, points, ratings, schedule, standings
+# `ratings` is aliased: simulate.run assigns a local ndarray named `ratings`,
+# which would shadow the module inside that function (UnboundLocalError)
+from . import config, fields, live_api, points, schedule, standings
+from . import ratings as official_ratings
 
 # Score-model constants, recalibrated against all completed 2026 rounds
 # (94 rounds / 6,667 player-rounds; see dgpt/calibrate.py). The 2021 values
@@ -100,7 +103,7 @@ def run(division: str, n_sims: int = DEFAULT_SIMS, seed: int | None = 2026,
         r for r in sched
         if not r["completed"] and r[division.lower()] and r["cls"] not in ("championship", "playoff")
     ]
-    official = ratings.current(division)  # standings rows are already overlaid
+    official = official_ratings.current(division)  # standings rows already overlaid
     for ev in upcoming_rows:
         roster = live_api.registered_roster(ev["tournament_id"], division)
         for pdga, info in roster.items():


### PR DESCRIPTION
## Broken main — my bug from #11

The refresh dispatched after merging #11 crashed:

```
File "dgpt/simulate.py", line 103, in run
    official = ratings.current(division)
UnboundLocalError: cannot access local variable 'ratings' where it is not associated with a value
```

`simulate.run` assigns a local ndarray named `ratings` (line ~117), so Python treats every `ratings` reference in the function as local — the module call added in #11 dies at function entry. **Every refresh crashes until this merges**, including tomorrow morning's first USWDGC live refresh (the loop's idle gate is why nothing has crashed since).

The #11 test suite exercised `standings.compute` but never executed `simulate.run` — that's how it slipped through.

## Fix

One-line alias: `from . import ratings as official_ratings`, used at the overlay site. The local ndarray keeps its name; no other behavior changes.

## Verification (properly, this time)

- `symtable` analysis: `official_ratings` resolves global in `run`, `ratings` stays local.
- **Executed `simulate.run` end-to-end** (200 sims, 40-player mocked table + roster addition) — completes, roster overlay path exercised.

After merge I'll re-dispatch the refresh to land the ratings snapshot + Buhr at 1063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_