### PR TITLE
Cache-bust the data fetches so the site tracks its own updates

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -28,13 +28,21 @@ const fmtPct = (x) =>
   : x < 0.0005 ? "<0.1%"
   : (x * 100).toFixed(1) + "%";
 
+// GitHub Pages serves data/*.json with Cache-Control: max-age=600 and caches
+// it at the CDN edge, so a fresh refresh could sit up to 10 min behind its own
+// data — and a browser hard-refresh can't force past the edge. A per-load
+// query string makes every page load a URL the edge has never cached, so the
+// site always shows the newest published data. (These files re-fetch only on
+// page load; within a session state.data/state.movers cache them in memory.)
+const bust = (path) => `${path}?t=${Date.now()}`;
+
 async function loadDiv(div) {
   if (!state.data[div]) {
-    const resp = await fetch(`data/${div}.json`);
+    const resp = await fetch(bust(`data/${div}.json`));
     state.data[div] = await resp.json();
   }
   if (state.movers === undefined) {
-    try { state.movers = await (await fetch("data/movers.json")).json(); }
+    try { state.movers = await (await fetch(bust("data/movers.json"))).json(); }
     catch { state.movers = null; }
   }
   return state.data[div];


### PR DESCRIPTION
## Problem

The Monday movers rollover was correct in every layer — data committed (`2026-07-13 → 2026-07-20`), the exact deployed commit carried it, the Pages deploy succeeded — yet the site kept showing the old box, and **a hard refresh didn't fix it**. Cause: GitHub Pages serves `data/*.json` with `Cache-Control: max-age=600` and caches it at the CDN edge (Fastly). A browser hard-refresh bypasses the *browser* cache but can't force past the *edge*, so the site can lag its own published data by up to ~10 minutes. It cleared on its own once the edge TTL expired.

This isn't Monday-specific — during live events every ~5-minute refresh sits behind the same 10-minute edge cache, so the site can trail the tournament it's supposed to be tracking.

## Fix

Append a per-load timestamp to the two data fetches:

```js
const bust = (path) => `${path}?t=${Date.now()}`;
... fetch(bust(`data/${div}.json`))
... fetch(bust("data/movers.json"))
```

Every page load requests a URL the edge has never cached, so the site reflects the newest publish within seconds. The files are still fetched only on page load (`state.data` / `state.movers` cache them in memory for the session), so this adds at most a couple of ~1 MB fetches per visit — no per-frame or per-interaction cost.

## Note

`app.js` itself is edge-cached the same way, so the *first* load after this deploys still comes from a cached `app.js` for up to ~10 min; after that the cache-busting is permanent. `node -c` passes; verified the generated URL carries a unique query string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_