### PR TITLE
Biggest Movers: add Rating Δ column; fix the Registration changes column

### DIFF
--- a/MODEL_IDEAS.md
+++ b/MODEL_IDEAS.md
@@ -110,4 +110,14 @@ If the effect is real but tiny, log it as "confirmed, immaterial" and move on.
 
 _Add new hunches here as they come up; promote to a full section when we dig in._
 
-- (none yet)
+- **[In-season TODO, ~Aug/Sep] Consume real playoff rosters, then re-enable playoff
+  registration tracking.** `simulate.run` gates the GMC/MVP fields on standings
+  rank, never on a registration list, so the model assumes every qualifier
+  attends. When DGPT playoff sign-ups open, teach the sim to use
+  `registered_field` for those events, then remove `playoff`/`championship` from
+  `movers.REG_GATED_CLASSES` so genuine playoff sign-ups/withdrawals show in the
+  Biggest Movers "Registration changes" column again. Until both land, that
+  column correctly hides playoff/Cup attendance (it's a qualification swing, not
+  a sign-up). Don't lift the exclusion on roster existence alone — PDGA may open
+  the roster before the model change, which would re-expose standings gating as
+  fake registration churn.

--- a/dgpt/movers.py
+++ b/dgpt/movers.py
@@ -23,6 +23,18 @@ APP_DATA = config.REPO_ROOT / "docs" / "data"
 MIN_DELTA = 0.02   # ignore noise-level changes
 TOP_N = 12
 
+# Attendance for these classes is gated by standings qualification, not a
+# registration list, so a player crossing the ~100% attendance threshold there
+# is a projected-qualification change, not a sign-up — it must NOT appear in the
+# "Registration changes" column (that signal already lives in the GMC/MVP % ).
+# RE-ADD WHEN PLAYOFF REGISTRATION OPENS: once the model consumes the real
+# playoff roster (simulate.run gating the GMC/MVP field on registered_field
+# instead of standings rank), drop the relevant class here so genuine playoff
+# sign-ups/withdrawals show again. Do NOT auto-lift on roster existence alone —
+# that would re-expose standings gating as registration until the model change
+# lands. See MODEL_IDEAS.md.
+REG_GATED_CLASSES = ("playoff", "championship")
+
 
 def _context(division: str, baseline: str, latest: str) -> tuple[dict, set[int]]:
     """Per-player 'why' context from the app bundle (written just before us):
@@ -33,13 +45,14 @@ def _context(division: str, baseline: str, latest: str) -> tuple[dict, set[int]]
     bundle = json.loads((APP_DATA / f"{division.lower()}.json").read_text(encoding="utf-8"))
     end_of = {s["tid"]: s["end"] for s in bundle.get("schedule", [])}
     completed = {s["tid"] for s in bundle.get("schedule", []) if s.get("completed")}
+    gated = {s["tid"] for s in bundle.get("schedule", []) if s.get("cls") in REG_GATED_CLASSES}
     last_result: dict[int, dict] = {}
     for p in bundle["players"]:
         recent = [b for b in p["banked"] if baseline < end_of.get(b["tid"], "") <= latest]
         if recent:
             b = max(recent, key=lambda b: end_of.get(b["tid"], ""))
             last_result[p["pdga"]] = {"tid": b["tid"], "pts": b["pts"], "place": b["place"]}
-    return last_result, completed
+    return last_result, completed, gated
 
 
 def _division_movers(division: str) -> dict | None:
@@ -76,7 +89,7 @@ def _division_movers(division: str) -> dict | None:
         return {int(r["pdga_number"]): r for r in rows if r["snapshot_date"] == date}
 
     base, cur = by_pdga(baseline), by_pdga(latest)
-    last_result, completed_tids = _context(division, baseline, latest)
+    last_result, completed_tids, gated_tids = _context(division, baseline, latest)
     movers = []
     for pdga, c in cur.items():
         b = base.get(pdga)
@@ -93,13 +106,15 @@ def _division_movers(division: str) -> dict | None:
         if b and b.get("registered") and c.get("registered") is not None:
             rb = {int(t) for t in b["registered"].split(";") if t}
             rc = {int(t) for t in c["registered"].split(";") if t}
-            reg_added = sorted(rc - rb)
-            # An event leaves the registered set either because the player
-            # de-registered (a real drop) or because it COMPLETED and is no
-            # longer a remaining event. Only the former is a registration
-            # change — exclude finished events so a played major (USWDGC)
-            # doesn't read as a dropped registration.
-            reg_removed = sorted(t for t in (rb - rc) if t not in completed_tids)
+            # Exclude standings-gated fields (playoffs, Cup): a change there is a
+            # qualification swing, not a sign-up. And a removal that's really a
+            # COMPLETED event (the player played it) isn't a dropped registration
+            # either. What remains: genuine sign-ups/withdrawals for still-open,
+            # registration-based events.
+            reg_added = sorted(t for t in (rc - rb) if t not in gated_tids)
+            reg_removed = sorted(
+                t for t in (rb - rc) if t not in gated_tids and t not in completed_tids
+            )
         # rating move over the window (why #3): PDGA's monthly ratings update
         # can shift Cup odds with no event played — often the whole story for a
         # quiet week. Snapshots record the rating in force at each date.

--- a/dgpt/movers.py
+++ b/dgpt/movers.py
@@ -93,6 +93,16 @@ def _division_movers(division: str) -> dict | None:
             rc = {int(t) for t in c["registered"].split(";") if t}
             reg_added = sorted(rc - rb)
             reg_removed = sorted(rb - rc)
+        # rating move over the window (why #3): PDGA's monthly ratings update
+        # can shift Cup odds with no event played — often the whole story for a
+        # quiet week. Snapshots record the rating in force at each date.
+        def _rating(r: dict | None) -> int | None:
+            try:
+                return int(r["rating"]) if r and r.get("rating") not in (None, "") else None
+            except (ValueError, TypeError):
+                return None
+        r_from, r_to = _rating(b), _rating(c)
+        rating_delta = (r_to - r_from) if (r_from is not None and r_to is not None) else None
         movers.append({
             "pdga": pdga,
             "name": c["name"],
@@ -104,6 +114,9 @@ def _division_movers(division: str) -> dict | None:
             "last_result": last_result.get(pdga),  # why #1: newest result since baseline
             "reg_added": reg_added,
             "reg_removed": reg_removed,
+            "rating_from": r_from,          # why #3: monthly ratings move
+            "rating_to": r_to,
+            "rating_delta": rating_delta,
         })
     movers.sort(key=lambda m: -abs(m["delta"]))
     return {"baseline": baseline, "latest": latest, "movers": movers[:TOP_N]}

--- a/dgpt/movers.py
+++ b/dgpt/movers.py
@@ -24,20 +24,22 @@ MIN_DELTA = 0.02   # ignore noise-level changes
 TOP_N = 12
 
 
-def _context(division: str, baseline: str, latest: str) -> tuple[dict, dict]:
+def _context(division: str, baseline: str, latest: str) -> tuple[dict, set[int]]:
     """Per-player 'why' context from the app bundle (written just before us):
-    the most recent banked result within the (baseline, latest] window, and the
-    schedule. Bounding at `latest` keeps the explanation frozen through the week
-    even as new events finalize before the next Monday roll-over."""
+    the most recent banked result within the (baseline, latest] window, plus the
+    set of events already completed. Bounding at `latest` keeps the explanation
+    frozen through the week even as new events finalize before the next Monday
+    roll-over."""
     bundle = json.loads((APP_DATA / f"{division.lower()}.json").read_text(encoding="utf-8"))
     end_of = {s["tid"]: s["end"] for s in bundle.get("schedule", [])}
+    completed = {s["tid"] for s in bundle.get("schedule", []) if s.get("completed")}
     last_result: dict[int, dict] = {}
     for p in bundle["players"]:
         recent = [b for b in p["banked"] if baseline < end_of.get(b["tid"], "") <= latest]
         if recent:
             b = max(recent, key=lambda b: end_of.get(b["tid"], ""))
             last_result[p["pdga"]] = {"tid": b["tid"], "pts": b["pts"], "place": b["place"]}
-    return last_result, end_of
+    return last_result, completed
 
 
 def _division_movers(division: str) -> dict | None:
@@ -74,7 +76,7 @@ def _division_movers(division: str) -> dict | None:
         return {int(r["pdga_number"]): r for r in rows if r["snapshot_date"] == date}
 
     base, cur = by_pdga(baseline), by_pdga(latest)
-    last_result, _ = _context(division, baseline, latest)
+    last_result, completed_tids = _context(division, baseline, latest)
     movers = []
     for pdga, c in cur.items():
         b = base.get(pdga)
@@ -92,7 +94,12 @@ def _division_movers(division: str) -> dict | None:
             rb = {int(t) for t in b["registered"].split(";") if t}
             rc = {int(t) for t in c["registered"].split(";") if t}
             reg_added = sorted(rc - rb)
-            reg_removed = sorted(rb - rc)
+            # An event leaves the registered set either because the player
+            # de-registered (a real drop) or because it COMPLETED and is no
+            # longer a remaining event. Only the former is a registration
+            # change — exclude finished events so a played major (USWDGC)
+            # doesn't read as a dropped registration.
+            reg_removed = sorted(t for t in (rb - rc) if t not in completed_tids)
         # rating move over the window (why #3): PDGA's monthly ratings update
         # can shift Cup odds with no event played — often the whole story for a
         # quiet week. Snapshots record the rating in force at each date.

--- a/docs/app.js
+++ b/docs/app.js
@@ -49,7 +49,8 @@ async function loadDiv(div) {
 }
 
 /* qualitative week-over-week movers panel (from prediction snapshots), with
-   the two usual "why"s: the newest result, and registration changes */
+   three "why"s: the newest result, the monthly ratings move, and registration
+   changes. A ratings shift alone can drive the Cup odds with no event played. */
 function moversHtml(d, div) {
   const m = state.movers && state.movers[div];
   if (!m || !m.movers.length) return "";
@@ -62,6 +63,14 @@ function moversHtml(d, div) {
     const lr = x.last_result
       ? `${nameOf.get(x.last_result.tid) || ""}: ${Math.round(x.last_result.pts)}${placeTag(x.last_result.place)}`
       : '<span class="dim">DNP</span>';
+    // rating move: signed + coloured when it changed, "—" when flat, blank when
+    // unknown (a pre-ratings-snapshot baseline can't be compared)
+    const rd = x.rating_delta;
+    const ratingCell = rd == null
+      ? '<span class="dim"></span>'
+      : rd === 0
+        ? '<span class="dim">—</span>'
+        : `<span class="${rd > 0 ? "movers-up" : "movers-down"}" title="${x.rating_from} → ${x.rating_to}">${rd > 0 ? "+" : "−"}${Math.abs(rd)}</span>`;
     const regs = [
       ...(x.reg_added || []).map((t) => `<span class="reg-chip reg-in">+ ${nameOf.get(t) || t}</span>`),
       ...(x.reg_removed || []).map((t) => `<span class="reg-chip reg-out">− ${nameOf.get(t) || t}</span>`),
@@ -71,13 +80,14 @@ function moversHtml(d, div) {
       <td><a class="plink" href="https://www.pdga.com/player/${x.pdga}" target="_blank" rel="noopener">${x.name}</a></td>
       <td class="num ${up ? "movers-up" : "movers-down"}">${pct0(x.champ_from)} → ${pct0(x.champ_to)}</td>
       <td class="num dim">${(x.delta > 0 ? "+" : "−") + Math.abs(Math.round(x.delta * 100))}</td>
+      <td class="num">${ratingCell}</td>
       <td>${lr}</td>
       <td>${regs}</td>
       <td class="num dim">${rank}</td></tr>`;
   }).join("");
   return `<details class="movers"><summary>Biggest movers — Cup odds since ${fmtD(m.baseline)}</summary>
     <table class="table-ledger detail-tbl"><thead><tr>
-      <th></th><th>Player</th><th class="num">Cup odds</th><th class="num">Δ</th><th>Last event</th><th>Registration changes</th><th class="num">Rank</th>
+      <th></th><th>Player</th><th class="num">Cup odds</th><th class="num">Δ</th><th class="num" title="Change in PDGA rating over the window — a monthly ratings update can move Cup odds with no event played">Rating Δ</th><th>Last event</th><th>Registration changes</th><th class="num">Rank</th>
     </tr></thead><tbody>${rows}</tbody></table></details>`;
 }
 


### PR DESCRIPTION
Three fixes to the Biggest Movers panel (all in `movers.py`; the column in `app.js`).

## 1. Rating Δ column — make ratings-driven moves legible

Every MPO mover this week was driven by PDGA's monthly ratings update (no MPO event), invisible in the panel — Knápek dropped ~10% → ~1% to make the Cup with nothing shown to explain it. Snapshots already record each player's `rating` at every date, so: `movers.py` adds `rating_from`/`rating_to`/`rating_delta`; `app.js` renders a signed, coloured **Rating Δ** column (`—` when flat, blank when the baseline predates rating snapshots; hover shows from→to).

```
MPO — rating-driven          FPO — results-driven (USWDGC)
  Knápek     Δodds −8%  RΔ −10    Midtlyng  Δodds +40%  RΔ +4
  Anderson   Δodds −12% RΔ −3     Chocek    Δodds −29%  RΔ −3
```

## 2. Completed events no longer read as dropped registrations

`reg_removed` flagged any event that left a player's registered set — but a *completed* event leaves it too, so everyone who played USWDGC showed as having dropped that registration (6 FPO movers). Now events marked `completed` in the bundle are excluded.

## 3. Standings-gated fields (playoffs, Cup) no longer show as sign-ups

The `registered` set is "events at ≥99.9% attendance prob." For the GMC/MVP playoffs and the Powerball Cup that probability comes from **standings qualification, not a registration list** — so Anneli and Sofia losing near-locked MVP spots after the ratings update read as *dropping an MVP registration that isn't even open yet*. Excluded `playoff`/`championship` classes from the reg diff; that signal already lives in the GMC/MVP % columns.

Deliberately class-based, **not** auto-lifting on roster existence: the sim still standings-gates playoff fields, so re-enabling genuine playoff-registration tracking requires first teaching `simulate.run` to consume the real roster. Captured as an in-season TODO in `MODEL_IDEAS.md` and flagged at the exclusion site (`REG_GATED_CLASSES`).

## Verification / rollout

Regenerated `movers.json` on the live `07-13 → 07-20` window: Rating Δ populated; USWDGC and playoff/Cup gone from the reg column; genuine sign-up changes preserved. Client + data only, no sim rerun. `node -c` and `py_compile` pass. Lands on the next `movers.json` regen (the live loop, within minutes); `app.js` handles the current field-less JSON gracefully until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)