### PR TITLE
Add the frozen-snapshot incident and its hardening item

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -45,6 +45,19 @@ pattern across them, not any single bug, is what this backlog addresses.
    interpretations of correct data.
 7. **The repo is drowning in machine commits.** ~690 of 825 commits are
    live-refresh data commits; the pack is 46 MiB and grows all season.
+8. **A snapshot written mid-incident becomes canonical for a week.**
+   `snapshot.record` keeps at most one snapshot per calendar day, first
+   write wins. On 2026-07-27 that write landed at 00:20:31Z — nine
+   minutes *before* the doubles pairing fix (dfc802b) — and froze the
+   broken roster (58 doubles registrations instead of 106, every team a
+   solo). The corrected refresh nine minutes later could not replace it,
+   and because the movers panel anchors both endpoints to Mondays, the
+   7/20→7/27 window would have served false "dropped registration" rows
+   until Aug 3. Correcting it meant hand-editing committed prediction
+   history (1f355ec). Note the two failure modes are independent: a
+   first-write-wins record, and a weekly panel that reads one specific
+   day. The 7/24–7/26 snapshots still carry the contaminated roster —
+   they feed no panel, but they do feed end-of-season grading.
 
 ## The plan
 
@@ -124,7 +137,29 @@ the cached final sheet and diff against the standings delta (catches
 engine drift per-event, immediately after banking, with no external
 fetch). Run validate's cross-check per-event as well as weekly.
 
-### 8. Small hygiene *(cheap, offseason)*
+### 8. Make daily snapshots correctable *(in-season safe)*
+
+Nothing today can revise a snapshot once written, so a bad one is
+load-bearing until the next calendar day — and for whatever the movers
+panel anchors to, a bad *Monday* is load-bearing for a week. Three
+pieces, cheapest first:
+
+- Add `python -m dgpt.refresh --resnapshot` to replace the current
+  day's block instead of skipping it, so a correction is a dispatch
+  rather than a hand-edit of `predictions/*.csv`.
+- Gate recording on the item-3 invariants: if ingest checks fail, skip
+  the snapshot and say so, rather than freezing a known-bad state as
+  the day of record. A missing day is far cheaper than a wrong one.
+- Consider last-write-wins per day, so a day converges on its final
+  state instead of its first. The objection is commit churn — a ~650-row
+  block rewritten every live refresh — which item 6 defuses by moving
+  data commits off main; sequence it after that.
+
+Also worth a flag in `evaluate`: grading currently trusts every
+snapshot equally, including ones taken while the pipeline was known
+broken.
+
+### 9. Small hygiene *(cheap, offseason)*
 
 - Pin `requirements.txt` (it's just unpinned `numpy`) and pin action
   majors to SHAs.


### PR DESCRIPTION
Docs only — adds tonight's incident to `HARDENING.md`.

## Incident 8 — a snapshot written mid-incident becomes canonical for a week

`snapshot.record` keeps at most one snapshot per calendar day, **first write wins**. On 2026-07-27 that write landed at 00:20:31Z — nine minutes *before* the doubles pairing fix (dfc802b) — freezing the broken roster (58 doubles registrations instead of 106). The corrected refresh nine minutes later couldn't replace it, and because the movers panel anchors both endpoints to Mondays, the 7/20→7/27 window would have served false "dropped registration" rows **until Aug 3**. Correcting it required hand-editing committed prediction history (1f355ec).

Two independent failure modes compounded: a first-write-wins record, *and* a weekly panel that reads one specific day. Also noted: 7/24–7/26 snapshots still carry the contaminated roster — they feed no panel, but they do feed end-of-season grading.

## Plan item 8 — make daily snapshots correctable *(in-season safe)*

Cheapest first:
- `--resnapshot` flag so a correction is a dispatch, not a hand-edit of `predictions/*.csv`
- gate recording on the item-3 ingest invariants — skip a snapshot when checks fail rather than freezing a known-bad day (a missing day is cheaper than a wrong one)
- consider last-write-wins per day, **sequenced after item 6**, which removes the commit-churn objection

Plus a note that `evaluate` currently trusts every snapshot equally, including ones taken while the pipeline was known broken.

Small hygiene renumbered 8 → 9.

## One process note

Item 5 of this doc says to retire the reused `claude/standings-attendance-bug-*` branch and use a fresh branch per change — I agree, but my standing instruction pins me to that branch, so I stayed on it rather than switch unilaterally. Say the word and I'll use fresh branches from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZTXBEnXrGGhFdZbhym6r6)_