### PR TITLE
Capture is_live's exit code under errexit

### DIFF
--- a/.github/workflows/live-refresh.yml
+++ b/.github/workflows/live-refresh.yml
@@ -89,7 +89,12 @@ jobs:
           }
 
           while :; do
-            is_live; live_rc=$?
+            # GitHub's default run shell is `bash -e`: a bare `is_live` that
+            # returns 3 (nothing live) would kill the script instantly with
+            # no output (observed 2026-07-27, first quiet night after this
+            # loop shipped). Capture the code in a condition context, which
+            # errexit exempts.
+            live_rc=0; is_live || live_rc=$?
             if [ "$live_rc" = 3 ]; then
               echo "No points event live — exiting (cron will restart when one is)."
               break


### PR DESCRIPTION
The live loop's new failure posture (#22) accidentally made the quiet "nothing live" path fatal: the default `bash -e` run shell kills the script the moment the bare `is_live` call returns its new exit code 3, before the clean-exit branch runs. Both overnight cron runs (01:22Z, 05:25Z on 2026-07-27) failed this way — exit 3, zero output.

One-line fix: capture the exit code in a condition context, which errexit exempts. Verified under `bash -e` that the old pattern exits 3 silently and the new one proceeds with `rc=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)